### PR TITLE
Add missing explicit Guava 18.0 compile dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ version flexVersion()
 dependencies {
     compile gradleApi()
     compile localGroovy()
+    compile 'com.google.guava:guava:18.0'
 
     testCompile 'org.hamcrest:hamcrest-all:1.3'
     testCompile 'com.netflix.nebula:nebula-test:2.2.1'


### PR DESCRIPTION
Fixing issue #9 
