### PR TITLE
Fix issue #22

### DIFF
--- a/src/test/groovy/com/palantir/jacoco/JacocoCoveragePluginTest.groovy
+++ b/src/test/groovy/com/palantir/jacoco/JacocoCoveragePluginTest.groovy
@@ -121,9 +121,14 @@ class JacocoCoveragePluginTest extends IntegrationSpec {
 
         then:
         def result = runTasksWithFailure('test', 'checkCoverage')
-        assert result.standardOutput.contains('Violations-are-reported-for-every-realm (0/3 LINE coverage < 1.00000)')
-        assert result.standardOutput.contains('HelloWorld.java (0/3 LINE coverage < 1.00000)')
-        assert result.standardOutput.contains('nebula/hello (0/3 LINE coverage < 1.00000)')
-        assert result.standardOutput.contains('nebula/hello/HelloWorld (0/3 LINE coverage < 1.00000)')
+
+        def fileViolation    = new CoverageViolation('HelloWorld.java', 0, 1.0, 3, CoverageType.LINE)
+        def classViolation   = new CoverageViolation('nebula/hello/HelloWorld', 0, 1.0, 3, CoverageType.LINE)
+        def packageViolation = new CoverageViolation('nebula/hello', 0, 1.0, 3, CoverageType.LINE)
+        def reportViolation  = new CoverageViolation('Violations-are-reported-for-every-realm', 0, 1.0, 3, CoverageType.LINE)
+        [fileViolation,
+        classViolation,
+        packageViolation,
+        reportViolation].every{result.standardOutput.contains(it.toString())}
     }
 }


### PR DESCRIPTION
This commit changes a test that relied on a string comparison of the violation reports. The test failed on systems where the locale or language of the java runtime is one that does **not** format decimal numbers with a dot separator for integer and fraction parts. For example the German output of the double value `1.00000` is `1,00000`.

The test now uses the class `CoverageViolation` where the string for the violation report is formatted (using `String#format`). Therefore it will always print the numbers according to the actual locale.
